### PR TITLE
Fixes incorrect use of async.queue

### DIFF
--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -62,6 +62,8 @@ createQueue = function(settings) {
           im.resize(task.options, function(err, stdout, stderr) {
             callback();
           });
+        } else {
+          callback();
         }
 
       });
@@ -78,6 +80,8 @@ createQueue = function(settings) {
         im.resize(task.options, function(err, stdout, stderr) {
           callback();
         });
+      } else {
+        callback();
       }
     }
 


### PR DESCRIPTION
As explained in https://github.com/caolan/async#queue the worker function of the queue must call its callback. If it is not called, the next task gets not processed.
This bug appears if overwriting is deactivated (default case) and the thumbnail already exists. The concerned worker function stops, since no callback is received.