### PR TITLE
Add support of options.source as a filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var thumb = require('node-thumbnail').thumb;
 // thumb(options, callback);
 
 thumb({
-  source: 'source/path',
+  source: 'source/path', // could be a filename: dest/path/image.jpg
   destination: 'dest/path',
   concurrency: 4
 }, function(err) {

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -96,7 +96,15 @@ createQueue = function(settings) {
 
 
 run = function(settings) {
-  var images = fs.readdirSync(settings.source);
+  var images;
+  
+  if (path.extname(settings.source)) {
+    images = [path.basename(settings.source)];
+    settings.source = path.dirname(settings.source);
+  } else {
+    images = fs.readdirSync(settings.source);
+  }
+  
   images = _.reject(images, function(file) {
     return _.indexOf(extensions, path.extname(file)) === -1;
   });

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -98,7 +98,7 @@ createQueue = function(settings) {
 run = function(settings) {
   var images;
   
-  if (path.extname(settings.source)) {
+  if (fs.statSync(settings.source).isFile()) {
     images = [path.basename(settings.source)];
     settings.source = path.dirname(settings.source);
   } else {


### PR DESCRIPTION
Detect if options.source is a file or a directory. When it's a file, convert options.source to a directory by using path.basename() and set the images list with [path.basename(options.source)]. When it's a directory (no extension), just read them.

```js
thumb({
  source: 'source/path', // could be a filename: dest/path/image.jpg
  destination: 'dest/path',
}, function(err) {
  console.log('All done!');
});
```