### PR TITLE
Add documentation of `quiet` default in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ defaults = {
   hashingType: 'sha1', // 'sha1', 'md5', 'sha256', 'sha512'
   width: 800,
   concurrency: <num of cpus>,
+  quiet: false, // if set to 'true', console.log status messages will be supressed
   overwrite: false,
   basename: undefined // basename of the thumbnail. If unset, the name of the source file is used as basename.
 };


### PR DESCRIPTION
First off, thank you for making this package :D It's super easy to use and does just what I was looking for 🎉 🎉 

This change adds some clarification to the README regarding the `quiet` property in the options. All console.log messages are disabled if `quiet` is set to true in the options, but I wasn't aware this option existed till I peeked in the code and saw it [here](https://github.com/honza/node-thumbnail/blob/master/src/thumbnail.js#L25). I am using this module in a unit test, so without `quiet` set to true, my Mocha test output would have the thumbnail name thrown in the middle of it.

Thank you again for making this module 🌮 