### PR TITLE
Improve error handling for missing src/dest

### DIFF
--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -153,12 +153,12 @@ exports.thumb = function(options, callback) {
     console.log('Destination \'' + options.destination + '\' does not exist.');
     return;
   } else if (destExists && !sourceExists) {
-		console.log('Source \'' + options.source + '\' does not exist.');
-		return;
-	} else {
-		console.log('Source \'' + options.source + '\' and destination \'' + options.destination + '\' do not exist.');
-		return;
-	}
+    console.log('Source \'' + options.source + '\' does not exist.');
+    return;
+  } else {
+    console.log('Source \'' + options.source + '\' and destination \'' + options.destination + '\' do not exist.');
+    return;
+  }
 
   if (callback) {
     done = callback;

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -97,14 +97,14 @@ createQueue = function(settings) {
 
 run = function(settings) {
   var images;
-  
+
   if (fs.statSync(settings.source).isFile()) {
     images = [path.basename(settings.source)];
     settings.source = path.dirname(settings.source);
   } else {
     images = fs.readdirSync(settings.source);
   }
-  
+
   images = _.reject(images, function(file) {
     return _.indexOf(extensions, path.extname(file)) === -1;
   });
@@ -144,12 +144,21 @@ exports.thumb = function(options, callback) {
 
   }
 
-  if (fs.existsSync(options.source) && fs.existsSync(options.destination)) {
+	var sourceExists = fs.existsSync(options.source);
+	var destExists = fs.existsSync(options.destination);
+
+  if (sourceExists && destExists) {
     settings = _.defaults(options, defaults);
-  } else {
-    console.log("Origin or destination doesn't exist.");
+  } else if (sourceExists && !destExists) {
+    console.log(`Destination '${options.destination}' does not exist.`);
     return;
-  }
+  } else if (destExists && !sourceExists) {
+		console.log(`Source '${options.source}' does not exist.`);
+		return;
+	} else {
+		console.log(`Source '${options.source}' and destination '${options.destination}' do not exist.`);
+		return;
+	}
 
   if (callback) {
     done = callback;

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -150,13 +150,13 @@ exports.thumb = function(options, callback) {
   if (sourceExists && destExists) {
     settings = _.defaults(options, defaults);
   } else if (sourceExists && !destExists) {
-    console.log(`Destination '${options.destination}' does not exist.`);
+    console.log('Destination \'' + options.destination + '\' does not exist.');
     return;
   } else if (destExists && !sourceExists) {
-		console.log(`Source '${options.source}' does not exist.`);
+		console.log('Source \'' + options.source + '\' does not exist.');
 		return;
 	} else {
-		console.log(`Source '${options.source}' and destination '${options.destination}' do not exist.`);
+		console.log('Source \'' + options.source + '\' and destination \'' + options.destination + '\' do not exist.');
 		return;
 	}
 

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -144,8 +144,8 @@ exports.thumb = function(options, callback) {
 
   }
 
-	var sourceExists = fs.existsSync(options.source);
-	var destExists = fs.existsSync(options.destination);
+  var sourceExists = fs.existsSync(options.source);
+  var destExists = fs.existsSync(options.destination);
 
   if (sourceExists && destExists) {
     settings = _.defaults(options, defaults);


### PR DESCRIPTION
Error messages previously did not distinguish between an invalid source input or destination input as the cause of the error, so this simple change clarifies what exactly the issue when console logging in the event of invalid input. There are now separate warnings for (1) if source doesn't exist, (2) if destination doesn't exist, or (3) if both don't exist, so someone encountering one of these issues will hopefully be able to address things more easily. Hope that's clear; let me know if there are any questions 🌮 