### PR TITLE
Fix TypeError involving logger

### DIFF
--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -124,7 +124,7 @@ run = function(settings) {
 
     queue.push({options: options}, function() {
       if (!settings.quiet) {
-        options.logger(image);
+        settings.logger(image);
       }
     });
 
@@ -150,15 +150,15 @@ exports.thumb = function(options, callback) {
   var sourceExists = fs.existsSync(options.source);
   var destExists = fs.existsSync(options.destination);
 
-  if (sourceExists && destExists) {
-    settings = _.defaults(options, defaults);
-  } else if (sourceExists && !destExists) {
+  settings = _.defaults(options, defaults);
+
+  if (sourceExists && !destExists) {
     options.logger('Destination \'' + options.destination + '\' does not exist.');
     return;
   } else if (destExists && !sourceExists) {
     options.logger('Source \'' + options.source + '\' does not exist.');
     return;
-  } else {
+  } else if (!sourceExists && !destExists) {
     options.logger('Source \'' + options.source + '\' and destination \'' + options.destination + '\' do not exist.');
     return;
   }


### PR DESCRIPTION
It looks like the module still functions/does the thumbnail conversion, but the error `TypeError: options.logger is not a function` was being thrown whenever the module is trying to log something. It happens both [here](https://github.com/honza/node-thumbnail/blob/master/src/thumbnail.js#L119) and further down the file [here](https://github.com/honza/node-thumbnail/blob/master/src/thumbnail.js#L156) as well. [This line](https://github.com/honza/node-thumbnail/blob/master/src/thumbnail.js#L154) appears to be where default properties get overridden by any user options, but its location in that `if` block means that if sibling `else if` blocks are executed, the logger is not on the `options` object unless the user explicitly provides one.

The two options for fixing this that came to mind are:

- pull the `_.defaults` on 154 line outside the if block and execute it unconditionally, before the source/dest checks, OR
- change the logger usage in the `else if` blocks to be `defaults.logger` instead, but downside of this is that the user could supply a custom logger but an invalid source/dest, and the error would still go through the default logger instead of their custom one

I opted for the first because of the issue mentioned in the second, but let me know what you think! The issue on line 127 was fixed simply by changing `options.logger` to `settings.logger` since `options` in that area seems to be referencing something separate.