### PR TITLE
Add basic support for native Promises

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,8 @@
     "strict": 0
   },
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   },
   "extends": "eslint:recommended"
 }

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -168,10 +168,10 @@ exports.thumb = function(options, callback) {
       options.logger(errorMessage);
 
       if (callback) {
-        return callback(errorMessage);
+        return callback(new Error(errorMessage));
       }
 
-      reject(errorMessage);
+      reject(new Error(errorMessage));
     }
 
     if (callback) {

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -135,25 +135,23 @@ run = function(settings, resolve, reject) {
 
 exports.thumb = function(options, callback) {
   return new Promise(function(resolve, reject) {
-    var settings;
+    var settings = _.defaults(options, defaults);
 
+    // options.args is present if run through the command line
     if (options.args) {
 
-      if (options.args.length != 2) {
+      if (options.args.length !== 2) {
         options.logger('Please provide a source and destination directories.');
         return;
       }
 
       options.source = options.args[0];
       options.destination = options.args[1];
-
     }
 
     var sourceExists = fs.existsSync(options.source);
     var destExists = fs.existsSync(options.destination);
     var errorMessage;
-
-    settings = _.defaults(options, defaults);
 
     if (sourceExists && !destExists) {
       errorMessage = 'Destination \'' + options.destination + '\' does not exist.';


### PR DESCRIPTION
This is my stab at implementing Promises so that this module supports both Node-style callbacks and Promises. Here's a rundown of the changes:

- `es6` env added to eslint config, otherwise eslint would complain that `Promise` was not defined. If you are opposed to this, another option would be to add `Promise` to the `globals` section in the eslint config.
- The `thumb` method returns a `new Promise`, wraps everything inside that Promise, and the Promise's `resolve` and `reject` get passed down the chain so that whenever `done`/`callback` are used, `resolve` and `reject` are in scope so they can be used instead if the user is using Promises instead of a callback.
- If there is an error with user input, the `err` passed to the callback (or to `reject`) is now an actual `Error` object instead of just a string. I'm not super experienced handling errors but this seemed like a good way to do it based on the information I could find (like from [here](https://www.joyent.com/node-js/production/design/errors)).

Let me know how that looks! Definitely open to feedback here, and I'm not 100% about everything. I think this might be a good stage to add some simple tests to the module, to always ensure both callbacks and Promises work, reject with errors at the right time with insufficient or invalid input, etc. I have a small ugly script I have been using to test this stuff myself but it might be worth adding some tests to the module itself.

Closes #11 