### PR TITLE
Add custom destination extension option

### DIFF
--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -31,7 +31,7 @@ defaults = {
   concurrency: os.cpus().length,
   quiet: false,
   overwrite: false,
-  ignore: false, // Ignore unsupported format,
+  ignore: false, // Ignore unsupported format
   logger: function(message) {
     console.log(message); // eslint-disable-line no-console
   }
@@ -54,6 +54,14 @@ isValidFilename = function(file) {
   return extensions.includes(path.extname(file).toLowerCase());
 };
 
+evalCustomExtension = function(customExtension, path) {
+  if (extensions.includes(customExtension)) {
+    return customExtension;
+  }
+
+  return path.extname(srcPath);
+};
+
 createQueue = function(settings, resolve, reject) {
   var finished = [];
 
@@ -71,7 +79,10 @@ createQueue = function(settings, resolve, reject) {
 
         task.options.dstPath = path.join(
           settings.destination,
-          d + '_' + settings.width + (extensions.includes(settings.extension) ? settings.extension : path.extname(task.options.srcPath))
+          d +
+            '_' +
+            settings.width +
+            evalCustomExtension(settings.extension, task.options.srcPath)
         );
 
         if (settings.overwrite || !fs.existsSync(task.options.dstPath)) {
@@ -88,7 +99,10 @@ createQueue = function(settings, resolve, reject) {
 
       task.options.dstPath = path.join(
         settings.destination,
-        settings.prefix + base + settings.suffix + (extensions.includes(settings.extension) ? settings.extension : ext)
+        settings.prefix +
+          base +
+          settings.suffix +
+          evalCustomExtension(settings.extension, name)
       );
 
       if (settings.overwrite || !fs.existsSync(task.options.dstPath)) {

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -54,7 +54,7 @@ isValidFilename = function(file) {
   return extensions.includes(path.extname(file).toLowerCase());
 };
 
-evalCustomExtension = function(customExtension, path) {
+evalCustomExtension = function(customExtension, srcPath) {
   if (extensions.includes(customExtension)) {
     return customExtension;
   }

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -31,7 +31,8 @@ defaults = {
   concurrency: os.cpus().length,
   quiet: false,
   overwrite: false,
-  ignore: false, // Ignore unsupported format
+  ignore: false, // Ignore unsupported format,
+  extension: 'auto',
   logger: function(message) {
     console.log(message); // eslint-disable-line no-console
   }
@@ -51,7 +52,7 @@ resizer = function(options, callback) {
 };
 
 isValidFilename = function(file) {
-  return _.indexOf(extensions, path.extname(file).toLowerCase()) > -1;
+  return extensions.includes(path.extname(file).toLowerCase());
 };
 
 createQueue = function(settings, resolve, reject) {
@@ -71,7 +72,7 @@ createQueue = function(settings, resolve, reject) {
 
         task.options.dstPath = path.join(
           settings.destination,
-          d + '_' + settings.width + path.extname(task.options.srcPath)
+          d + '_' + settings.width + (extensions.includes(settings.extension) ? settings.extension : path.extname(task.options.srcPath))
         );
 
         if (settings.overwrite || !fs.existsSync(task.options.dstPath)) {
@@ -88,9 +89,9 @@ createQueue = function(settings, resolve, reject) {
 
       task.options.dstPath = path.join(
         settings.destination,
-        settings.prefix + base + settings.suffix + ext
+        settings.prefix + base + settings.suffix + (extensions.includes(settings.extension) ? settings.extension : ext)
       );
-
+      
       if (settings.overwrite || !fs.existsSync(task.options.dstPath)) {
         resizer(task.options, function() {
           finished.push(task.options);

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -32,7 +32,6 @@ defaults = {
   quiet: false,
   overwrite: false,
   ignore: false, // Ignore unsupported format,
-  extension: 'auto',
   logger: function(message) {
     console.log(message); // eslint-disable-line no-console
   }
@@ -91,7 +90,7 @@ createQueue = function(settings, resolve, reject) {
         settings.destination,
         settings.prefix + base + settings.suffix + (extensions.includes(settings.extension) ? settings.extension : ext)
       );
-      
+
       if (settings.overwrite || !fs.existsSync(task.options.dstPath)) {
         resizer(task.options, function() {
           finished.push(task.options);


### PR DESCRIPTION
Added new "extension" option to the options object

If provided, node-thumbnail will use it as the thumbnail file extension as long as it is a valid file extension (that is, is inside the extensions array). If the option is not passed or an invalid extension is provided, the default behaviour will take place (original file extension).