### PR TITLE
Fixed invalid format error when ignore = true

### DIFF
--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -155,21 +155,20 @@ run = function(settings, resolve, reject) {
   createQueue(settings, resolve, reject);
 
   _.each(images, function(image) {
-    if (!isValidFilename(image) && !settings.ignore) {
-      return true;
+    if (isValidFilename(image)) {
+   
+      options = {
+        srcPath: path.join(settings.source, image),
+        width: settings.width,
+        basename: settings.basename
+      };
+      queue.push({ options: options }, function() {
+        if (!settings.quiet) {
+          settings.logger(image);
+        }
+      });
+    
     }
-
-    options = {
-      srcPath: path.join(settings.source, image),
-      width: settings.width,
-      basename: settings.basename
-    };
-
-    queue.push({ options: options }, function() {
-      if (!settings.quiet) {
-        settings.logger(image);
-      }
-    });
   });
 };
 


### PR DESCRIPTION
The code was failing when there is a file or folder that was not in supported format list even when ignore:true is set in the options. I think there is no need to return true in _.each loop because the code is already throwing an error if the format is not supported and ignore is set to false. Instead, if there was no error thrown, add only files that are supported.
 