### PR TITLE
Add callback call in the resizer function.

### DIFF
--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -41,6 +41,7 @@ extensions = ['.jpg', '.jpeg', '.png'];
 resizer = (options, callback) =>
   jimp.read(options.srcPath, (err, file) => {
     if (err) {
+      if(done) done(null, err);
       throw err;
     }
 

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -41,7 +41,7 @@ extensions = ['.jpg', '.jpeg', '.png'];
 resizer = (options, callback) =>
   jimp.read(options.srcPath, (err, file) => {
     if (err) {
-      if(done) return done(null, err);
+      if(done) return done(file, err);
       throw err;
     }
 

--- a/src/thumbnail.js
+++ b/src/thumbnail.js
@@ -41,7 +41,7 @@ extensions = ['.jpg', '.jpeg', '.png'];
 resizer = (options, callback) =>
   jimp.read(options.srcPath, (err, file) => {
     if (err) {
-      if(done) done(null, err);
+      if(done) return done(null, err);
       throw err;
     }
 


### PR DESCRIPTION
Thank the team first as this library is useful in one of my project.

But when using it, I encountered one problem, when using in expressjs, which is when the user upload a fake picture (like after changing the ext of another non-pic file) and the server try to make a thumbnail of it, there will be an exception (unkown MIME type) in the jimp which will cause the resizer function to throw out the exception. But in expressjs, I cannot catch the exception which will cause the process terminate.

I am not sure whether I could find a better solution in expressjs side, but for now I just folk this project and add the callback in resizer function so that I can process the exception in the expressjs.

It will be appreciated if someone can provide a better solution without changing this lib!